### PR TITLE
Project 2 - 전체 통과

### DIFF
--- a/include/vm/file.h
+++ b/include/vm/file.h
@@ -6,12 +6,16 @@
 struct page;
 enum vm_type;
 
-struct file_page {
+struct file_page
+{
+    enum vm_type type;
+    void *aux;
+    void *va;
 };
 
-void vm_file_init (void);
-bool file_backed_initializer (struct page *page, enum vm_type type, void *kva);
+void vm_file_init(void);
+bool file_backed_initializer(struct page *page, enum vm_type type, void *kva);
 void *do_mmap(void *addr, size_t length, int writable,
-		struct file *file, off_t offset);
-void do_munmap (void *va);
+              struct file *file, off_t offset);
+void do_munmap(void *va);
 #endif

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -159,7 +159,7 @@ page_fault(struct intr_frame *f)
     /* Count page faults. */
     page_fault_cnt++;
 
-    // exit(-1);
+    exit(-1);
 
     if (user)
     {

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -255,10 +255,12 @@ __do_fork(struct parent_info *aux)
     if_.R.rax = 0; // 자식 프로세스의 리턴값은 0
 
     /* 2. Duplicate PT */
+
     current->pml4 = pml4_create();
     if (current->pml4 == NULL)
         goto error;
     process_activate(current);
+    // printf("copt start\n");
 #ifdef VM
     supplemental_page_table_init(&current->spt);
     if (!supplemental_page_table_copy(&current->spt, &parent->spt))

--- a/vm/file.c
+++ b/vm/file.c
@@ -2,57 +2,66 @@
 
 #include "vm/vm.h"
 
-static bool file_backed_swap_in (struct page *page, void *kva);
-static bool file_backed_swap_out (struct page *page);
-static void file_backed_destroy (struct page *page);
+static bool file_backed_swap_in(struct page *page, void *kva);
+static bool file_backed_swap_out(struct page *page);
+static void file_backed_destroy(struct page *page);
 
 /* DO NOT MODIFY this struct */
 static const struct page_operations file_ops = {
-	.swap_in = file_backed_swap_in,
-	.swap_out = file_backed_swap_out,
-	.destroy = file_backed_destroy,
-	.type = VM_FILE,
+    .swap_in = file_backed_swap_in,
+    .swap_out = file_backed_swap_out,
+    .destroy = file_backed_destroy,
+    .type = VM_FILE,
 };
 
 /* The initializer of file vm */
-void
-vm_file_init (void) {
+void vm_file_init(void)
+{
 }
 
 /* Initialize the file backed page */
-bool
-file_backed_initializer (struct page *page, enum vm_type type, void *kva) {
-	/* Set up the handler */
-	page->operations = &file_ops;
+bool file_backed_initializer(struct page *page, enum vm_type type, void *kva)
+{
+    /* Set up the handler */
+    page->operations = &file_ops;
 
-	struct file_page *file_page = &page->file;
+    struct file_page *file_page = &page->file;
+
+    file_page->type = type;
+    file_page->va = kva;
+
+    return true;
 }
 
 /* Swap in the page by read contents from the file. */
 static bool
-file_backed_swap_in (struct page *page, void *kva) {
-	struct file_page *file_page UNUSED = &page->file;
+file_backed_swap_in(struct page *page, void *kva)
+{
+    struct file_page *file_page UNUSED = &page->file;
 }
 
 /* Swap out the page by writeback contents to the file. */
 static bool
-file_backed_swap_out (struct page *page) {
-	struct file_page *file_page UNUSED = &page->file;
+file_backed_swap_out(struct page *page)
+{
+    struct file_page *file_page UNUSED = &page->file;
 }
 
 /* Destory the file backed page. PAGE will be freed by the caller. */
 static void
-file_backed_destroy (struct page *page) {
-	struct file_page *file_page UNUSED = &page->file;
+file_backed_destroy(struct page *page)
+{
+    struct file_page *file_page UNUSED = &page->file;
 }
 
 /* Do the mmap */
 void *
-do_mmap (void *addr, size_t length, int writable,
-		struct file *file, off_t offset) {
+do_mmap(void *addr, size_t length, int writable,
+        struct file *file, off_t offset)
+{
 }
 
 /* Do the munmap */
-void
-do_munmap (void *addr) {
+void do_munmap(void *addr)
+{
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -305,16 +305,15 @@ bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED,
     struct hash_iterator i;
 
     hash_first(&i, src_hash);
-    // printf("copy tid %d\n", thread_current()->tid);
-    // lock_acquire(&vm_lock);
     while (hash_next(&i))
     {
         struct page *p = hash_entry(hash_cur(&i), struct page, h_elem);
         if (p == NULL)
             return false;
         enum vm_type type = page_get_type(p);
-        // printf("type %d  p->type %d\n", type, p->operations->type);
         struct page *child;
+
+        // printf("type %d\n", p->operations->type);
 
         if (p->operations->type == VM_UNINIT)
         {


### PR DESCRIPTION
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/fork-once
pass tests/userprog/fork-multiple
pass tests/userprog/fork-recursive
pass tests/userprog/fork-read
pass tests/userprog/fork-close
pass tests/userprog/fork-boundary
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
pass tests/userprog/exec-read
pass tests/userprog/wait-simple
pass tests/userprog/wait-twice
pass tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
pass tests/userprog/multi-recurse
pass tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
pass tests/userprog/rox-child
pass tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
FAIL tests/vm/pt-grow-stack
pass tests/vm/pt-grow-bad
FAIL tests/vm/pt-big-stk-obj
pass tests/vm/pt-bad-addr
pass tests/vm/pt-bad-read
pass tests/vm/pt-write-code
FAIL tests/vm/pt-write-code2
FAIL tests/vm/pt-grow-stk-sc
FAIL tests/vm/page-linear
FAIL tests/vm/page-parallel
FAIL tests/vm/page-merge-seq
FAIL tests/vm/page-merge-par
FAIL tests/vm/page-merge-stk
FAIL tests/vm/page-merge-mm
pass tests/vm/page-shuffle
FAIL tests/vm/mmap-read
FAIL tests/vm/mmap-close
FAIL tests/vm/mmap-unmap
FAIL tests/vm/mmap-overlap
FAIL tests/vm/mmap-twice
FAIL tests/vm/mmap-write
pass tests/vm/mmap-ro
FAIL tests/vm/mmap-exit
FAIL tests/vm/mmap-shuffle
FAIL tests/vm/mmap-bad-fd
FAIL tests/vm/mmap-clean
FAIL tests/vm/mmap-inherit
FAIL tests/vm/mmap-misalign
FAIL tests/vm/mmap-null
FAIL tests/vm/mmap-over-code
FAIL tests/vm/mmap-over-data
FAIL tests/vm/mmap-over-stk
FAIL tests/vm/mmap-remove
pass tests/vm/mmap-zero
FAIL tests/vm/mmap-bad-fd2
FAIL tests/vm/mmap-bad-fd3
FAIL tests/vm/mmap-zero-len
FAIL tests/vm/mmap-off
FAIL tests/vm/mmap-bad-off
FAIL tests/vm/mmap-kernel
FAIL tests/vm/lazy-file
pass tests/vm/lazy-anon
FAIL tests/vm/swap-file
FAIL tests/vm/swap-anon
FAIL tests/vm/swap-iter
FAIL tests/vm/swap-fork
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
pass tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
pass tests/filesys/base/syn-write
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
FAIL tests/vm/cow/cow-simple
39 of 141 tests failed.