### PR TITLE
hash func 수정, hash_insert 오류 해결

### DIFF
--- a/vm/anon.c
+++ b/vm/anon.c
@@ -42,6 +42,7 @@ void vm_anon_init(void)
         struct slot *insert_disk = (struct slot *)malloc(sizeof(struct slot));
         insert_disk->used = 0;
         insert_disk->index = i;
+        insert_disk->page = NULL;
         if (insert_disk == NULL)
             printf("NULL\n");
         lock_acquire(&swap_lock);
@@ -143,7 +144,7 @@ anon_destroy(struct page *page)
 unsigned anon_page_hash(const struct hash_elem *p_, void *aux UNUSED)
 {
     const struct slot *p = hash_entry(p_, struct slot, swap_elem);
-    return hash_bytes(&p->page->va, sizeof p->page->va);
+    return hash_bytes(&p->index, sizeof p->index);
 }
 
 bool anon_page_less(const struct hash_elem *a_, const struct hash_elem *b_, void *aux UNUSED)
@@ -151,5 +152,5 @@ bool anon_page_less(const struct hash_elem *a_, const struct hash_elem *b_, void
     const struct slot *a = hash_entry(a_, struct slot, swap_elem);
     const struct slot *b = hash_entry(b_, struct slot, swap_elem);
 
-    return a->page->va < b->page->va;
+    return a->index < b->index;
 }


### PR DESCRIPTION
page -> NULL 로 설정하고 hash func을 `page->va`를 기준으로 hash 계산을 했기 때문에 insert가 진행되지 않았음.

hash func 계산 기준을 변하지 않을 disk slot의 index로 변경해주어 해결했음.